### PR TITLE
Incorporate various enhancements from the Net

### DIFF
--- a/README
+++ b/README
@@ -6,55 +6,33 @@
 #   wmctrl was originally written by Tomas Styblo with contributions from    #
 #   from others.  Its home page is http://tripie.sweb.cz/utils/wmctrl/.      #
 #                                                                            #
-#   The version here is enhanced with various changes that people around     #
-#   the Net had added in their own divergent versions.  This version is      #
-#   meant to gather all of those improvements together in one place.         #
-#   It also contains the full release history of wmctrl (one commit          #
-#   per release) because it starts from the Conservatory archive at          #
-#   https://github.com/Conservatory/wmctrl.  The relevant part of the        #
-#   Conservatory's README is below, lightly edited.                          #
+#   The version here contains various enhancements that people around the    #
+#   Net had added in their own divergent versions.  The two main sources     #
+#   of these enhancements were https://github.com/dancor/wmctrl and          #
+#   https://github.com/geekless/wmctrl.  The additions include these         #
+#   new command-line options/actions:                                        #
 #                                                                            #
-#   =====================================================================    #
+#     -Y: iconify (Vadim Ushakov)                                            #
+#     -S: sort window list in stacking order (Vadim Ushakov)                 #
+#     -j: list current desktop (Kevin Der)                                   #
+#     -r -y: like -e but reactivate after the move (Chris Piro )             #
+#     -E: get-title (Dan Corson)                                             #
+#     -z: lower window (Dan Corson)                                          #
 #                                                                            #
-#   Because wmctrl does not appear to have any publicly accessible version   #
-#   control repository, we created a Conservatory Git repository for it.     #
-#   We don't know if Tomas Styblo still accepts bug reports for wmctrl,      #
-#   but if you run into a bug you could try reporting it to him and see      #
-#   what happens.  (As of this writing on 2018-09-09, the latest official    #
-#   wmctrl release was 1.07 in January 2005.)  Please also feel free to      #
-#   file bugs here.  Although I don't consider this copy of wmctrl to be     #
-#   "official" and I'm certainly not committing to maintain it, I'll merge   #
-#   easy fixes or enhancements if they don't take too much time to review.   #
+#   Other improvements are a typo fix for the --help output, and some        #
+#   fixes for build-time compiler warnings.                                  #
 #                                                                            #
-#   About the Conservatory copy of wmctrl that this started from:            #
-#   -------------------------------------------------------------            #
+#   This repository also contains the full release history of wmctrl (one    #
+#   commit per release), because it is based on the Conservatory archive     #
+#   at https://github.com/Conservatory/wmctrl.                               #
 #                                                                            #
-#   The Conservatory (https://conservatory.github.io/) is a place where      #
-#   free software that has no other public version-controlled home on the    #
-#   Internet is made available in a git repository.  For wmctrl, we started  #
-#   from http://tripie.sweb.cz/utils/wmctrl/dist/wmctrl-1.07.tar.gz and      #
-#   then deduced the names of the previous releases.  We have committed      #
-#   each upstream release as one git revision, starting from 1.00, using     #
-#   https://github.com/Conservatory/conservatory.github.io/blob/master/\     #
-#   conservatory-import and the upstream ChangeLog to automate the process.  #
+#   I don't know if Tomas Styblo still accepts bug reports for wmctrl, as    #
+#   the last version he released was 1.07 in January 2005.  Please feel to   #
+#   file bug reports and enhancements here.  Although I don't consider this  #
+#   copy to be "official", and can't commit to putting in much effort as     #
+#   a maintainer, I'll try to review and merge easy fixes and enhancements.  #
 #                                                                            #
-#   There are other version-controlled copies of wmctrl on the Internet.     #
-#   We found at least these two, and there may be others:                    #
-#                                                                            #
-#     * https://github.com/geekless/wmctrl                                   #
-#                                                                            #
-#       Adds -Y (iconify) and -S (sort in stacking order) options.           #
-#       Also backports some 64-bit-data fixes from a Debian patch.           #
-#                                                                            #
-#     * https://github.com/dancor/wmctrl                                     #
-#                                                                            #
-#       Adds -j (list current desktop), -z (lower window),                   #
-#       and some other interesting new options.                              #
-#                                                                            #
-#   Those two started from a top-skim of wmctrl 1.07, though, so they        #
-#   didn't preserve the full upstream release history.  Later @kfogel        #
-#   cloned the Conservatory copy and then merged those enhancements into     #
-#   his copy.  Below is the original content of the upstream README file.    #
+#   Below is the original content of the upstream 1.07 README.               #
 #                                                                            #
 ##############################################################################
 

--- a/README
+++ b/README
@@ -1,21 +1,33 @@
 ##############################################################################
 #                                                                            #
-#   This is the Conservatory archive of the wmctrl, a Unix command-line      #
-#   tool to interact with an EWMH/NetWM-compatible X Window Manager.         #
+#   wmctrl is free software (open source software), a Unix command-line      #
+#   tool for interacting with an EWMH/NetWM-compatible X Window Manager.     #
 #                                                                            #
-#   wmctrl is free software (open source software), written by Tomas Styblo  #
-#   with contributions from others.  http://tripie.sweb.cz/utils/wmctrl/ is  #
-#   its home page.                                                           #
+#   wmctrl was originally written by Tomas Styblo with contributions from    #
+#   from others.  Its home page is http://tripie.sweb.cz/utils/wmctrl/.      #
+#                                                                            #
+#   The version here is enhanced with various changes that people around     #
+#   the Net had added in their own divergent versions.  This version is      #
+#   meant to gather all of those improvements together in one place.         #
+#   It also contains the full release history of wmctrl (one commit          #
+#   per release) because it starts from the Conservatory archive at          #
+#   https://github.com/Conservatory/wmctrl.  The relevant part of the        #
+#   Conservatory's README is below, lightly edited.                          #
+#                                                                            #
+#   =====================================================================    #
 #                                                                            #
 #   Because wmctrl does not appear to have any publicly accessible version   #
-#   control repository, we've created this Conservatory Git repository.      #
-#   We're not sure if Tomas Styblo or any of the other contributors are      #
-#   are currently accepting bug reports, but if you run into a bug you       #
-#   could try reporting it upstream and see what happens.  (As of this       #
-#   writing on 2018-09-08, the latest wmctrl release was in January 2005.)   #
+#   control repository, we created a Conservatory Git repository for it.     #
+#   We don't know if Tomas Styblo still accepts bug reports for wmctrl,      #
+#   but if you run into a bug you could try reporting it to him and see      #
+#   what happens.  (As of this writing on 2018-09-09, the latest official    #
+#   wmctrl release was 1.07 in January 2005.)  Please also feel free to      #
+#   file bugs here.  Although I don't consider this copy of wmctrl to be     #
+#   "official" and I'm certainly not committing to maintain it, I'll merge   #
+#   easy fixes or enhancements if they don't take too much time to review.   #
 #                                                                            #
-#   About the Conservatory and its copy of wmctrl:                           #
-#   ----------------------------------------------                           #
+#   About the Conservatory copy of wmctrl that this started from:            #
+#   -------------------------------------------------------------            #
 #                                                                            #
 #   The Conservatory (https://conservatory.github.io/) is a place where      #
 #   free software that has no other public version-controlled home on the    #
@@ -39,14 +51,10 @@
 #       Adds -j (list current desktop), -z (lower window),                   #
 #       and some other interesting new options.                              #
 #                                                                            #
-#   Those two started from a top-skim of wmctrl 1.07, though, so they don't  #
-#   preserve the full upstream release history.  It'd be nice if someone     #
-#   were to clone this Conservatory copy and then re-port the enhancements   #
-#   from those other repositories to create a canonical new wmctrl release.  #
-#                                                                            #
-#   In the meantime, this README is the only file we've changed from what's  #
-#   in upstream, and the only change we made was to add this note.  Below    #
-#   is the original content of the README file.                              #
+#   Those two started from a top-skim of wmctrl 1.07, though, so they        #
+#   didn't preserve the full upstream release history.  Later @kfogel        #
+#   cloned the Conservatory copy and then merged those enhancements into     #
+#   his copy.  Below is the original content of the upstream README file.    #
 #                                                                            #
 ##############################################################################
 

--- a/main.c
+++ b/main.c
@@ -58,6 +58,7 @@ Free Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 "  -r <WIN> -t <DESK>   Move the window to the specified desktop.\n" \
 "  -r <WIN> -e <MVARG>  Resize and move the window around the desktop.\n" \
 "                       The format of the <MVARG> argument is described below.\n" \
+"  -r <WIN> -y <MVARG>  Resize and move like above, then reactivate.\n" \
 "  -r <WIN> -b <STARG>  Change the state of the window. Using this option it's\n" \
 "                       possible for example to make the window maximized,\n" \
 "                       minimized or fullscreen. The format of the <STARG>\n" \
@@ -264,7 +265,7 @@ int main (int argc, char **argv) { /* {{{ */
         }
     }
    
-    while ((opt = getopt(argc, argv, "FGVvhlupidmxa:r:s:c:t:w:k:o:n:g:e:b:z:E:N:I:T:R:")) != -1) {
+    while ((opt = getopt(argc, argv, "FGVvhlupidmxa:r:s:c:t:w:k:o:n:g:e:y:b:z:E:N:I:T:R:")) != -1) {
         missing_option = 0;
         switch (opt) {
             case 'F':
@@ -296,7 +297,7 @@ int main (int argc, char **argv) { /* {{{ */
             case 'r':
                 options.param_window = optarg;
                 break; 
-            case 't': case 'e': case 'b': case 'N': case 'I': case 'T':
+            case 't': case 'e': case 'b': case 'N': case 'I': case 'T': case 'y':
                 options.param = optarg;
                 action = opt;
                 break;
@@ -356,7 +357,7 @@ int main (int argc, char **argv) { /* {{{ */
             ret = wm_info(disp);
             break;
         case 'a': case 'c': case 'R': case 'z': case 'E':
-        case 't': case 'e': case 'b': case 'N': case 'I': case 'T':
+        case 't': case 'e': case 'b': case 'N': case 'I': case 'T': case 'y':
             if (! options.param_window) {
                 fputs("No window was specified.\n", stderr);
                 return EXIT_FAILURE;
@@ -882,6 +883,7 @@ static int window_say_title (Display *disp, Window win) {
 }
 
 static int action_window (Display *disp, Window win, char mode) {/*{{{*/
+    int rv;
     p_verbose("Using window: 0x%.8lx\n", win);
     switch (mode) {
         case 'a':
@@ -893,6 +895,12 @@ static int action_window (Display *disp, Window win, char mode) {/*{{{*/
         case 'e':
             /* resize/move the window around the desktop => -r -e */
             return window_move_resize(disp, win, options.param);
+
+        case 'y':
+            /* resize/move the window, then activate it */
+            rv = window_move_resize(disp, win, options.param);
+            activate_window(disp, win, TRUE);
+            return rv;
 
         case 'b':
             /* change state of a window => -r -b */

--- a/main.c
+++ b/main.c
@@ -49,6 +49,7 @@ Free Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 "  -l                   List windows managed by the window manager.\n" \
 "  -d                   List desktops. The current desktop is marked\n" \
 "                       with an asterisk.\n" \
+"  -j                   List current desktop.\n" \
 "  -s <DESK>            Switch to the specified desktop.\n" \
 "  -a <WIN>             Activate the window by switching to its desktop and\n" \
 "                       raising it.\n" \
@@ -195,6 +196,7 @@ static int client_msg(Display *disp, Window win, char *msg,
         unsigned long data2, unsigned long data3,
         unsigned long data4);
 static int list_windows (Display *disp);
+static int list_current_desktop (Display *disp);
 static int list_desktops (Display *disp);
 static int showing_desktop (Display *disp);
 static int change_viewport (Display *disp);
@@ -265,7 +267,7 @@ int main (int argc, char **argv) { /* {{{ */
         }
     }
    
-    while ((opt = getopt(argc, argv, "FGVvhlupidmxa:r:s:c:t:w:k:o:n:g:e:y:b:z:E:N:I:T:R:")) != -1) {
+    while ((opt = getopt(argc, argv, "FGVvhlupidjmxa:r:s:c:t:w:k:o:n:g:e:y:b:z:E:N:I:T:R:")) != -1) {
         missing_option = 0;
         switch (opt) {
             case 'F':
@@ -346,6 +348,9 @@ int main (int argc, char **argv) { /* {{{ */
             break;
         case 'l':
             ret = list_windows(disp);
+            break;
+        case 'j':
+            ret = list_current_desktop(disp);
             break;
         case 'd':
             ret = list_desktops(disp);
@@ -1035,6 +1040,25 @@ static int action_window_str (Display *disp, char mode) {/*{{{*/
         }
     }
 }/*}}}*/
+
+
+static int list_current_desktop (Display *disp) {/*{{{*/
+    unsigned long *cur_desktop = NULL;
+    Window root = DefaultRootWindow(disp);
+    if (! (cur_desktop = (unsigned long *)get_property(disp, root,
+            XA_CARDINAL, "_NET_CURRENT_DESKTOP", NULL))) {
+        if (! (cur_desktop = (unsigned long *)get_property(disp, root,
+                XA_CARDINAL, "_WIN_WORKSPACE", NULL))) {
+            fputs("Cannot get current desktop properties. "
+                  "(_NET_CURRENT_DESKTOP or _WIN_WORKSPACE property)"
+                  "\n", stderr);
+            g_free(cur_desktop);
+            return EXIT_FAILURE;
+        }
+    }
+    printf("%-2d\n", *cur_desktop);
+    return EXIT_SUCCESS;
+}
 
 static int list_desktops (Display *disp) {/*{{{*/
     unsigned long *num_desktops = NULL;

--- a/main.c
+++ b/main.c
@@ -1485,7 +1485,7 @@ static gchar *get_property (Display *disp, Window win, /*{{{*/
     }
 
     /* null terminate the result to make string handling easier */
-    tmp_size = (ret_format / 8) * ret_nitems;
+    tmp_size = (ret_format / (32 / sizeof(long))) * ret_nitems;
     ret = g_malloc(tmp_size + 1);
     memcpy(ret, ret_prop, tmp_size);
     ret[tmp_size] = '\0';

--- a/main.c
+++ b/main.c
@@ -874,9 +874,14 @@ static int window_move_resize (Display *disp, Window win, char *arg) {/*{{{*/
     }
 }/*}}}*/
 
-static int action_window (Display *disp, Window win, char mode) {/*{{{*/
-    XTextProperty text_prop_return;
+static int window_say_title (Display *disp, Window win) {
+    gchar *title_utf8 = get_window_title(disp, win);
+    printf("%s\n", title_utf8);
+    g_free(title_utf8);
+    return EXIT_SUCCESS;
+}
 
+static int action_window (Display *disp, Window win, char mode) {/*{{{*/
     p_verbose("Using window: 0x%.8lx\n", win);
     switch (mode) {
         case 'a':
@@ -916,12 +921,7 @@ static int action_window (Display *disp, Window win, char mode) {/*{{{*/
             // iconify
             return XLowerWindow(disp, win);
         case 'E':
-            // say title
-            // FIXME: why isn't XSetWMName used for the other title stuff in
-            // wmctrl?
-            XGetWMName(disp, win, &text_prop_return);
-            printf("%s\n", text_prop_return.value);
-            return EXIT_SUCCESS;
+            return window_say_title(disp, win);
 
         default:
             fprintf(stderr, "Unknown action: '%c'\n", mode);

--- a/main.c
+++ b/main.c
@@ -264,7 +264,7 @@ int main (int argc, char **argv) { /* {{{ */
         }
     }
    
-    while ((opt = getopt(argc, argv, "FGVvhlupidmxa:r:s:c:t:w:k:o:n:g:e:b:z:N:I:T:R:")) != -1) {
+    while ((opt = getopt(argc, argv, "FGVvhlupidmxa:r:s:c:t:w:k:o:n:g:e:b:z:E:N:I:T:R:")) != -1) {
         missing_option = 0;
         switch (opt) {
             case 'F':
@@ -289,7 +289,7 @@ int main (int argc, char **argv) { /* {{{ */
             case 'p':
                 options.show_pid = 1;
                 break;
-            case 'a': case 'c': case 'R': case 'z':
+            case 'a': case 'c': case 'R': case 'z': case 'E':
                 options.param_window = optarg;
                 action = opt;
                 break;
@@ -355,7 +355,7 @@ int main (int argc, char **argv) { /* {{{ */
         case 'm':
             ret = wm_info(disp);
             break;
-        case 'a': case 'c': case 'R': case 'z':
+        case 'a': case 'c': case 'R': case 'z': case 'E':
         case 't': case 'e': case 'b': case 'N': case 'I': case 'T':
             if (! options.param_window) {
                 fputs("No window was specified.\n", stderr);
@@ -875,6 +875,8 @@ static int window_move_resize (Display *disp, Window win, char *arg) {/*{{{*/
 }/*}}}*/
 
 static int action_window (Display *disp, Window win, char mode) {/*{{{*/
+    XTextProperty text_prop_return;
+
     p_verbose("Using window: 0x%.8lx\n", win);
     switch (mode) {
         case 'a':
@@ -911,7 +913,15 @@ static int action_window (Display *disp, Window win, char mode) {/*{{{*/
             return EXIT_SUCCESS;
 
         case 'z':
+            // iconify
             return XLowerWindow(disp, win);
+        case 'E':
+            // say title
+            // FIXME: why isn't XSetWMName used for the other title stuff in
+            // wmctrl?
+            XGetWMName(disp, win, &text_prop_return);
+            printf("%s\n", text_prop_return.value);
+            return EXIT_SUCCESS;
 
         default:
             fprintf(stderr, "Unknown action: '%c'\n", mode);

--- a/main.c
+++ b/main.c
@@ -661,28 +661,28 @@ static void window_set_title (Display *disp, Window win, /* {{{ */
     /* set name */
     if (title_local) {
       XChangeProperty(disp, win, XA_WM_NAME, XA_STRING, 8, PropModeReplace,
-          title_local, strlen(title_local));
+          (guchar *) title_local, strlen(title_local));
     }
     else {
       XDeleteProperty(disp, win, XA_WM_NAME);
     }
     XChangeProperty(disp, win, XInternAtom(disp, "_NET_WM_NAME", False), 
         XInternAtom(disp, "UTF8_STRING", False), 8, PropModeReplace,
-        title_utf8, strlen(title_utf8));
+        (guchar *) title_utf8, strlen(title_utf8));
   }
 
   if (mode == 'T' || mode == 'I') {
     /* set icon name */
     if (title_local) {
       XChangeProperty(disp, win, XA_WM_ICON_NAME, XA_STRING, 8, PropModeReplace,
-          title_local, strlen(title_local));
+          (guchar *) title_local, strlen(title_local));
     }
     else {
       XDeleteProperty(disp, win, XA_WM_ICON_NAME);
     }
     XChangeProperty(disp, win, XInternAtom(disp, "_NET_WM_ICON_NAME", False), 
         XInternAtom(disp, "UTF8_STRING", False), 8, PropModeReplace,
-        title_utf8, strlen(title_utf8));
+        (guchar *) title_utf8, strlen(title_utf8));
   }
 
   g_free(title_utf8);
@@ -1094,7 +1094,7 @@ static int list_current_desktop (Display *disp) {/*{{{*/
             return EXIT_FAILURE;
         }
     }
-    printf("%-2d\n", *cur_desktop);
+    printf("%-2d\n", *((int *) cur_desktop));
     return EXIT_SUCCESS;
 }
 

--- a/main.c
+++ b/main.c
@@ -113,7 +113,7 @@ Free Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 "\n" \
 "                       The -x option may be used to interpret the argument\n" \
 "                       as a string, which is matched against the window's\n" \
-"                       class name (WM_CLASS property). Th first matching\n" \
+"                       class name (WM_CLASS property). The first matching\n" \
 "                       window is used. The matching isn't case sensitive\n" \
 "                       and the string may appear in any position\n" \
 "                       of the class name. So it's recommended to  always use\n" \

--- a/main.c
+++ b/main.c
@@ -1517,6 +1517,16 @@ static gchar *get_property (Display *disp, Window win, /*{{{*/
      *
      * long_length = Specifies the length in 32-bit multiples of the
      *               data to be retrieved.
+     *
+     * NOTE:  see 
+     * http://mail.gnome.org/archives/wm-spec-list/2003-March/msg00067.html
+     * In particular:
+     *
+     * 	When the X window system was ported to 64-bit architectures, a
+     * rather peculiar design decision was made. 32-bit quantities such
+     * as Window IDs, atoms, etc, were kept as longs in the client side
+     * APIs, even when long was changed to 64 bits.
+     *
      */
     if (XGetWindowProperty(disp, win, xa_prop_name, 0, MAX_PROPERTY_VALUE_LEN / 4, False,
             xa_prop_type, &xa_ret_type, &ret_format,     
@@ -1532,7 +1542,10 @@ static gchar *get_property (Display *disp, Window win, /*{{{*/
     }
 
     /* null terminate the result to make string handling easier */
-    tmp_size = (ret_format / (32 / sizeof(long))) * ret_nitems;
+
+    tmp_size = (ret_format / 8) * ret_nitems;
+    /* Correct 64 Architecture implementation of 32 bit data */
+    if(ret_format==32) tmp_size *= sizeof(long)/4;
     ret = g_malloc(tmp_size + 1);
     memcpy(ret, ret_prop, tmp_size);
     ret[tmp_size] = '\0';

--- a/main.c
+++ b/main.c
@@ -745,6 +745,33 @@ static int close_window (Display *disp, Window win) {/*{{{*/
             0, 0, 0, 0, 0);
 }/*}}}*/
 
+static gchar * normalize_wm_state_name(const char * name)
+{
+    char * short_names[] = {
+        "modal", "sticky", "maximized_vert", "maximized_horz",
+        "shaded", "skip_taskbar", "skip_pager", "hidden",
+        "fullscreen", "above", "below", 0};
+
+    int i;
+    for (i = 0; short_names[i]; i++)
+    {
+        if (strcmp(short_names[i], name) == 0)
+        {
+            gchar * upcase = g_ascii_strup(name, -1);
+            gchar * result = g_strdup_printf("_NET_WM_STATE_%s", upcase);
+            g_free(upcase);
+            return result;
+        }
+    }
+
+    if (strcmp("undecorated", name) == 0)
+    {
+        return g_strdup("_OB_WM_STATE_UNDECORATED");
+    }
+
+    return g_strdup(name);
+}
+
 static int window_state (Display *disp, Window win, char *arg) {/*{{{*/
     unsigned long action;
     Atom prop1 = 0;
@@ -758,8 +785,8 @@ static int window_state (Display *disp, Window win, char *arg) {/*{{{*/
     }
 
     if ((p1 = strchr(arg, ','))) {
-        gchar *tmp_prop1, *tmp1;
-        
+        gchar *tmp_prop1;
+
         *p1 = '\0';
 
         /* action */
@@ -780,17 +807,16 @@ static int window_state (Display *disp, Window win, char *arg) {/*{{{*/
 
         /* the second property */
         if ((p2 = strchr(p1, ','))) {
-            gchar *tmp_prop2, *tmp2;
+            gchar *tmp_prop2;
             *p2 = '\0';
             p2++;
             if (strlen(p2) == 0) {
                 fputs("Invalid zero length property.\n", stderr);
                 return EXIT_FAILURE;
             }
-            tmp_prop2 = g_strdup_printf("_NET_WM_STATE_%s", tmp2 = g_ascii_strup(p2, -1));
+            tmp_prop2 = normalize_wm_state_name(p2);
             p_verbose("State 2: %s\n", tmp_prop2); 
             prop2 = XInternAtom(disp, tmp_prop2, False);
-            g_free(tmp2);
             g_free(tmp_prop2);
         }
 
@@ -799,13 +825,11 @@ static int window_state (Display *disp, Window win, char *arg) {/*{{{*/
             fputs("Invalid zero length property.\n", stderr);
             return EXIT_FAILURE;
         }
-        tmp_prop1 = g_strdup_printf("_NET_WM_STATE_%s", tmp1 = g_ascii_strup(p1, -1));
+        tmp_prop1 = normalize_wm_state_name(p1);
         p_verbose("State 1: %s\n", tmp_prop1); 
         prop1 = XInternAtom(disp, tmp_prop1, False);
-        g_free(tmp1);
         g_free(tmp_prop1);
 
-        
         return client_msg(disp, win, "_NET_WM_STATE", 
             action, (unsigned long)prop1, (unsigned long)prop2, 0, 0);
     }

--- a/wmctrl.1
+++ b/wmctrl.1
@@ -220,6 +220,10 @@ Include geometry information in the output of the
 action.
 
 .TP
+.B \-S
+List windows in stacking order (bottom to top).
+
+.TP
 .B \-i
 Interpret window arguments 
 .RI ( <WIN> )

--- a/wmctrl.1
+++ b/wmctrl.1
@@ -72,6 +72,12 @@ Close the window
 gracefully.
 
 .TP
+.BI \-Y " <WIN>"
+Iconify the window
+.I <WIN>
+\[char46]
+
+.TP
 .B \-d
 List all desktops managed by the window manager. One line is output
 for each desktop, with the line broken up into space separated


### PR DESCRIPTION
This merges various improvements to wmctrl, mostly from two repositories:

* https://github.com/geekless/wmctrl
* https://github.com/dancor/wmctrl

Note that each of those repositories includes changes from people
besides the repository owner.  Collectively, the changes introduce
these new options:

* -Y: iconify  (Vadim Ushakov)
* -S: sort window list in stacking order (Vadim Ushakov)
* -j: list current desktop (Kevin Der)
* -r -y: like -e but reactivate after the move (Chris Piro )
* -E: get-title (Dan Corson)
* -z: lower window (Dan Corson)

The changes also include a typo fix for the --help output and some casts
to avoid compiler warnings.